### PR TITLE
Update NSIS.template.in

### DIFF
--- a/cmake/modules/NSIS.template.in
+++ b/cmake/modules/NSIS.template.in
@@ -443,11 +443,20 @@ Section "${APPLICATION_NAME}" SEC_APPLICATION
    File "${MING_BIN}\libcrypto-10.dll"
    File "${MING_BIN}\libssl-10.dll"
    File "${MING_BIN}\libstdc++-6.dll"
-   File "${MING_BIN}\libwebp-4.dll"
+   File "${MING_BIN}\libwebp-5.dll"
    File "${MING_BIN}\libxslt-1.dll"
    File "${MING_BIN}\libxml2-2.dll"
    File "${MING_BIN}\zlib1.dll"
    File "${MING_BIN}\libsqlite3-0.dll"
+   
+     #Añadido Sergio
+   File "${MING_BIN}\libharfbuzz-0.dll"
+   File "${MING_BIN}\libfreetype-6.dll"
+   File "${MING_BIN}\libglib-2.0-0.dll"
+   File "${MING_BIN}\libintl-8.dll"
+   File "${MING_BIN}\Qt5Positioning.dll"
+   #Fin Añadido
+
 
    ;QtKeyChain stuff
    File "${MING_BIN}\libqt5keychain.dll"


### PR DESCRIPTION
-Añadidas libs necesarias para crear exe de Windows.
-Cambiado la libwebp-4-dll por libwebp-5.dll ya que la cuatro ya no se usa.